### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The Infisical [Model Context Protocol](https://modelcontextprotocol.com/) server allows you to integrate with Infisical APIs through function calling. This protocol supports various tools to interact with Infisical.
 
+<a href="https://glama.ai/mcp/servers/@Infisical/infisical-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Infisical/infisical-mcp-server/badge" alt="Infisical Server MCP server" />
+</a>
+
 ## Setup
 
 ### Environment variables


### PR DESCRIPTION
This PR adds a badge for the [Infisical MCP Server](https://glama.ai/mcp/servers/@Infisical/infisical-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Infisical/infisical-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Infisical/infisical-mcp-server/badge" alt="Infisical Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an image badge to the README that links directly to the Infisical MCP server page on glama.ai.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->