### PR TITLE
CLIENT_ID -> CLIENT_SECRET for client secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the following to your `claude_desktop_config.json`. See [here](https://model
       "env": {
         "INFISICAL_HOST_URL": "https://<custom-host-url>.com", // Optional
         "INFISICAL_UNIVERSAL_AUTH_CLIENT_ID": "<machine-identity-universal-auth-client-id>",
-        "INFISICAL_UNIVERSAL_AUTH_CLIENT_ID": "<machine-identity-universal-auth-client-secret"
+        "INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET": "<machine-identity-universal-auth-client-secret"
       }
     }
   }


### PR DESCRIPTION
Fixes a typo in the `README.md` for the client secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the environment variable key in the README example for Claude Desktop integration to accurately distinguish between client ID and client secret configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->