### PR TITLE
fix: resolve list-projects issues with "all" type   parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 .DS_Store
 infisical-mcp-*.tgz
+.claude

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ node_modules
 dist
 .DS_Store
 infisical-mcp-*.tgz
-.claude

--- a/src/index.ts
+++ b/src/index.ts
@@ -397,7 +397,7 @@ const createFolderSchema = {
 
 const listProjectsSchema = {
 	zod: z.object({
-		type: z.enum(["secret-manager", "cert-manager", "kms", "ssh", "all"])
+		type: z.enum(["secret-manager", "cert-manager", "kms", "ssh", "all"]).default("all")
 	}),
 	capability: {
 		name: AvailableTools.ListProjects,
@@ -691,6 +691,11 @@ server.setRequestHandler(CallToolRequestSchema, async req => {
 					hostUrl += "/api";
 				}
 
+				let url = `${hostUrl}/v1/workspace`;
+				if (data.type !== "all") {
+					url += `?type=${data.type}`;
+				}
+
 				const res = await axios.get<{
 					workspaces: {
 						hasDeleteProtection: boolean;
@@ -705,7 +710,7 @@ server.setRequestHandler(CallToolRequestSchema, async req => {
 							id: string;
 						}[];
 					}[];
-				}>(`${hostUrl}/v1/workspace?type=${data.type}`, {
+				}>(url, {
 					headers: {
 						Authorization: `Bearer ${accessToken}`
 					}


### PR DESCRIPTION
 ## Summary
  - Fix default value not being applied when no `type` parameter is provided to list-projects
  - Prevent 422 errors when using `type: "all"` by conditionally adding the query parameter
  - Resolves https://github.com/Infisical/infisical-mcp-server/issues/9

  ## Tests Performed
  - [x] Test list-projects without specifying type parameter (should default to "all")
  - [x] Test list-projects with `type: "all"` (should not throw 422 error)
  - [x] Test list-projects with specific types like "secret-manager"

 
