### PR TITLE
fix: make list-projects type parameter optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -397,7 +397,7 @@ const createFolderSchema = {
 
 const listProjectsSchema = {
 	zod: z.object({
-		type: z.enum(["secret-manager", "cert-manager", "kms", "ssh", "all"])
+		type: z.enum(["secret-manager", "cert-manager", "kms", "ssh"]).optional()
 	}),
 	capability: {
 		name: AvailableTools.ListProjects,
@@ -407,7 +407,7 @@ const listProjectsSchema = {
 			properties: {
 				type: {
 					type: "string",
-					description: "The type of projects to retrieve. If not specified, `all` projects will be retrieved."
+					description: "The type of projects to retrieve (e.g. 'secret-manager', 'cert-manager', 'kms', 'ssh'). If not specified, all projects will be retrieved."
 				}
 			}
 		}
@@ -705,7 +705,7 @@ server.setRequestHandler(CallToolRequestSchema, async req => {
 							id: string;
 						}[];
 					}[];
-				}>(`${hostUrl}/v1/workspace?type=${data.type}`, {
+				}>(`${hostUrl}/v1/workspace${data.type ? `?type=${data.type}` : ""}`, {
 					headers: {
 						Authorization: `Bearer ${accessToken}`
 					}


### PR DESCRIPTION
## Summary

The `type` field in `listProjectsSchema` has two issues:

1. **Required in Zod but optional in MCP inputSchema** — The Zod schema requires `type`, causing a validation error (`MCP error -32603: Invalid arguments: type: Required`) when `list-projects` is called without arguments. The MCP `inputSchema` correctly describes it as optional.

2. **Invalid `"all"` enum value** — The Zod schema accepts `"all"`, but the Infisical API (`/v1/workspace?type=all`) rejects it with HTTP 422.

## Changes

- Make `type` optional in the Zod schema (`.optional()`)
- Remove the invalid `"all"` enum value
- Omit the `?type=` query parameter when `type` is not provided (returns all projects)
- Update the description to list valid enum values explicitly

## Before

```
# No type → Zod validation error
MCP error -32603: Invalid arguments: type: Required

# type=all → API error  
Error retrieving projects: Request failed with status code 422
```

## After

```
# No type → returns all projects (no query param sent)
Projects retrieved successfully: [...]

# type=secret-manager → returns filtered projects
Projects retrieved successfully: [...]
```