### PR TITLE
Fix invite-members array schemas

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -495,6 +495,11 @@ const listProjectsSchema = {
   },
 };
 
+const stringArrayInputSchema = {
+  type: "array",
+  items: { type: "string" },
+};
+
 const inviteMembersToProjectSchema = {
   zod: z.object({
     projectId: z.string(),
@@ -513,17 +518,17 @@ const inviteMembersToProjectSchema = {
           description: "The ID of the project to invite members to (required)",
         },
         emails: {
-          type: "array",
+          ...stringArrayInputSchema,
           description:
             "The emails of the members to invite. Either usernames or emails must be provided.",
         },
         usernames: {
-          type: "array",
+          ...stringArrayInputSchema,
           description:
             "The usernames of the members to invite. Either usernames or emails must be provided.",
         },
         roleSlugs: {
-          type: "array",
+          ...stringArrayInputSchema,
           description:
             "The role slugs of the members to invite. If not provided, the default role 'member' will be used. Ask the user to confirm the role they want to use if not explicitly specified.",
         },


### PR DESCRIPTION
## Summary
- add explicit string items schemas for emails, usernames, and roleSlugs on invite-members-to-project
- reuse a small string-array schema helper so the three array fields stay consistent

This addresses the strict JSON Schema validation failure reported in Infisical/infisical#6315, where clients reject the whole MCP session because array schemas are missing items.

## Verification
- npm run build