### PR TITLE
fix(list-secrets): mask secret values by default (opt-in via includeValues)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -264,11 +264,12 @@ const listSecretsSchema = {
     secretPath: z.string().default("/"),
     expandSecretReferences: z.boolean().default(true),
     includeImports: z.boolean().default(true),
+    includeValues: z.boolean().default(false),
   }),
   capability: {
     name: AvailableTools.ListSecrets,
     description:
-      "List all secrets in a given Infisical project and environment",
+      "List all secrets in a given Infisical project and environment. Secret values are MASKED by default (only keys returned) to prevent accidental leaks to LLM context / provider logs. Pass includeValues=true ONLY when the caller genuinely needs the values.",
     inputSchema: {
       type: "object",
       properties: {
@@ -293,6 +294,11 @@ const listSecretsSchema = {
         includeImports: {
           type: "boolean",
           description: "Whether to include secret imports (Defaults to true)",
+        },
+        includeValues: {
+          type: "boolean",
+          description:
+            "Whether to include secret values in the response (Defaults to false for safety). When false, response only contains secretKey for each secret. Set true ONLY when caller genuinely needs values - this exposes them to the LLM context.",
         },
       },
       required: ["projectId", "environmentSlug"],
@@ -631,17 +637,17 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         includeImports: data.includeImports,
       });
 
+      const mapSecret = (secret: { secretKey: string; secretValue: string }) =>
+        data.includeValues
+          ? { secretKey: secret.secretKey, secretValue: secret.secretValue }
+          : { secretKey: secret.secretKey };
+
       const response = {
-        secrets: secrets.secrets.map((secret) => ({
-          secretKey: secret.secretKey,
-          secretValue: secret.secretValue,
-        })),
+        valuesMasked: !data.includeValues,
+        secrets: secrets.secrets.map(mapSecret),
         ...(secrets.imports && {
           imports: secrets.imports?.map((imp) => {
-            const parsedImportSecrets = imp.secrets.map((secret) => ({
-              secretKey: secret.secretKey,
-              secretValue: secret.secretValue,
-            }));
+            const parsedImportSecrets = imp.secrets.map(mapSecret);
 
             return {
               ...imp,


### PR DESCRIPTION
Closes #21.

## What

Add an `includeValues: boolean` parameter (default `false`) to `list-secrets`. When false, the response only contains `secretKey` for each secret; the `secretValue` field is omitted entirely. Also add a `valuesMasked: <bool>` flag to the response for agent self-introspection.

## Why

See #21 for the full rationale. TL;DR: `list-secrets` is consumed by LLMs and unconditionally returning `secretValue` causes accidental leaks to provider logs on every exploratory call. `get-secret` doesn't have this issue because the caller names what it wants.

## Changes

Single file: `src/index.ts` (+15/-9 lines).

1. Zod schema: add `includeValues: z.boolean().default(false)`
2. JSON schema (`inputSchema.properties`): add `includeValues` field with safety-oriented description
3. Description of the capability: clarify default-masked behavior
4. Handler: replace inline mapping with `mapSecret` helper that conditionally includes `secretValue` based on `data.includeValues`
5. Response: add `valuesMasked: !data.includeValues` flag

## Testing

Tested at three levels before opening this PR:

1. **Syntax**: `node --check dist/index.js` → OK after `npm run build`
2. **Unit**: mapper called in isolation. `includeValues=false` → `{secretKey: "X"}`. `includeValues=true` → `{secretKey: "X", secretValue: "..."}`
3. **Live stdio**: spawned the freshly-built MCP via stdio with a real Infisical instance, called `list-secrets` on a path with 2 known secrets:
   - No `includeValues` → response: `{"valuesMasked":true,"secrets":[{"secretKey":"OPENAI_API_KEY"},{"secretKey":"OAUTH_CLIENT_SECRET"}]}`
   - `includeValues: true` → response: `{"valuesMasked":false,"secrets":[{"secretKey":"OPENAI_API_KEY","secretValue":"..."},{"secretKey":"OAUTH_CLIENT_SECRET","secretValue":"..."}]}`

This patched binary has been deployed locally as a workaround in my environment since 2026-05-26.

The repo has no test suite, so I've stopped here — happy to add one if you'd like guidance on the framework you'd prefer.

## Backward compatibility

This is a breaking change for callers that relied on values being present unconditionally. As discussed in #21, I'd suggest bumping to `0.1.0` to signal the change.

## Related

- #5 (open since 2025-06-05) is in the same security family — `removeAccessToken` from error messages. Could be reviewed/merged together.
