### PR TITLE
fix(create-secret,update-secret): forward secretComment + 4 other SDK fields

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,6 +138,11 @@ const createSecretSchema = {
     secretName: z.string(),
     secretValue: z.string().optional(),
     secretPath: z.string().default("/"),
+    secretComment: z.string().optional(),
+    secretReminderNote: z.string().optional(),
+    secretReminderRepeatDays: z.number().optional(),
+    skipMultilineEncoding: z.boolean().optional(),
+    tagIds: z.array(z.string()).optional(),
   }),
   capability: {
     name: AvailableTools.CreateSecret,
@@ -166,6 +171,29 @@ const createSecretSchema = {
         secretPath: {
           type: "string",
           description: "The path of the secret to create (Defaults to /)",
+        },
+        secretComment: {
+          type: "string",
+          description:
+            "Optional comment/description for the secret (for documentation purposes)",
+        },
+        secretReminderNote: {
+          type: "string",
+          description: "Optional reminder note attached to the secret",
+        },
+        secretReminderRepeatDays: {
+          type: "number",
+          description: "Optional reminder repeat interval in days",
+        },
+        skipMultilineEncoding: {
+          type: "boolean",
+          description:
+            "Skip multiline encoding for secret values containing newlines",
+        },
+        tagIds: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional array of tag IDs to attach to the secret",
         },
       },
       required: ["projectId", "environmentSlug", "secretName"],
@@ -218,6 +246,11 @@ const updateSecretSchema = {
     newSecretName: z.string().optional(),
     secretValue: z.string().optional(),
     secretPath: z.string().default("/"),
+    secretComment: z.string().optional(),
+    secretReminderNote: z.string().optional(),
+    secretReminderRepeatDays: z.number().optional(),
+    skipMultilineEncoding: z.boolean().optional(),
+    tagIds: z.array(z.string()).optional(),
   }),
   capability: {
     name: AvailableTools.UpdateSecret,
@@ -250,6 +283,29 @@ const updateSecretSchema = {
         secretPath: {
           type: "string",
           description: "The path of the secret to update (Defaults to /)",
+        },
+        secretComment: {
+          type: "string",
+          description:
+            "Optional comment/description for the secret. Note: if omitted, existing comment is preserved (partial update).",
+        },
+        secretReminderNote: {
+          type: "string",
+          description: "Optional reminder note attached to the secret",
+        },
+        secretReminderRepeatDays: {
+          type: "number",
+          description: "Optional reminder repeat interval in days",
+        },
+        skipMultilineEncoding: {
+          type: "boolean",
+          description:
+            "Skip multiline encoding for secret values containing newlines",
+        },
+        tagIds: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional array of tag IDs to attach to the secret",
         },
       },
       required: ["projectId", "environmentSlug", "secretName"],
@@ -558,14 +614,27 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     if (name === AvailableTools.CreateSecret) {
       const data = createSecretSchema.zod.parse(args);
 
+      const createOpts: Parameters<
+        ReturnType<typeof infisicalSdk.secrets>["createSecret"]
+      >[1] = {
+        environment: data.environmentSlug,
+        projectId: data.projectId,
+        secretPath: data.secretPath,
+        secretValue: data.secretValue ?? "",
+      };
+      if (data.secretComment !== undefined)
+        createOpts.secretComment = data.secretComment;
+      if (data.secretReminderNote !== undefined)
+        createOpts.secretReminderNote = data.secretReminderNote;
+      if (data.secretReminderRepeatDays !== undefined)
+        createOpts.secretReminderRepeatDays = data.secretReminderRepeatDays;
+      if (data.skipMultilineEncoding !== undefined)
+        createOpts.skipMultilineEncoding = data.skipMultilineEncoding;
+      if (data.tagIds !== undefined) createOpts.tagIds = data.tagIds;
+
       const { secret } = await infisicalSdk
         .secrets()
-        .createSecret(data.secretName, {
-          environment: data.environmentSlug,
-          projectId: data.projectId,
-          secretPath: data.secretPath,
-          secretValue: data.secretValue ?? "",
-        });
+        .createSecret(data.secretName, createOpts);
 
       return {
         content: [
@@ -601,14 +670,30 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     if (name === AvailableTools.UpdateSecret) {
       const data = updateSecretSchema.zod.parse(args);
 
+      const updateOpts: Parameters<
+        ReturnType<typeof infisicalSdk.secrets>["updateSecret"]
+      >[1] = {
+        environment: data.environmentSlug,
+        projectId: data.projectId,
+        secretPath: data.secretPath,
+      };
+      if (data.secretValue !== undefined)
+        updateOpts.secretValue = data.secretValue;
+      if (data.newSecretName !== undefined)
+        updateOpts.newSecretName = data.newSecretName;
+      if (data.secretComment !== undefined)
+        updateOpts.secretComment = data.secretComment;
+      if (data.secretReminderNote !== undefined)
+        updateOpts.secretReminderNote = data.secretReminderNote;
+      if (data.secretReminderRepeatDays !== undefined)
+        updateOpts.secretReminderRepeatDays = data.secretReminderRepeatDays;
+      if (data.skipMultilineEncoding !== undefined)
+        updateOpts.skipMultilineEncoding = data.skipMultilineEncoding;
+      if (data.tagIds !== undefined) updateOpts.tagIds = data.tagIds;
+
       const { secret } = await infisicalSdk
         .secrets()
-        .updateSecret(data.secretName, {
-          environment: data.environmentSlug,
-          projectId: data.projectId,
-          secretPath: data.secretPath,
-          secretValue: data.secretValue ?? "",
-        });
+        .updateSecret(data.secretName, updateOpts);
 
       return {
         content: [


### PR DESCRIPTION
Closes #23.

## What

Add 5 optional fields to `create-secret` and `update-secret` (matching `@infisical/sdk@4.0.1` `BaseSecretOptions`), and fix partial-update semantics for `update-secret`.

New fields exposed on both tools:

- `secretComment` (string) — the primary motivation, see #23
- `secretReminderNote` (string)
- `secretReminderRepeatDays` (number)
- `skipMultilineEncoding` (boolean)
- `tagIds` (string[])

## Why

See #23 for the full rationale. TL;DR:

1. The MCP currently drops `secretComment` silently, forcing consumers to maintain a separate REST PATCH workaround just to attach documentation.
2. `update-secret` always sent `secretValue: ""` even when the caller didn't pass it, defeating the documented partial-update semantics. Agents trying to update only a comment couldn't.

## Changes

Single file: `src/index.ts` (+97/-12 lines).

### Schemas
1. `createSecretSchema.zod` + `inputSchema.properties`: add `secretComment`, `secretReminderNote`, `secretReminderRepeatDays`, `skipMultilineEncoding`, `tagIds` (all `z.string().optional()` or equivalent).
2. `updateSecretSchema.zod` + `inputSchema.properties`: same 5 fields.

### Handlers
1. `create-secret`: build a `createOpts` object, conditionally add each new field if defined, pass to `createSecret(name, createOpts)`. The `secretValue: data.secretValue ?? ""` default is preserved (a value is required for creation).
2. `update-secret`: build an `updateOpts` object, conditionally add **every** optional field including `secretValue` and `newSecretName`. This restores true partial-update semantics — callers can now update just the comment without touching the value.

The handlers use `Parameters<ReturnType<typeof infisicalSdk.secrets>["createSecret"]>[1]` to type the opts object — keeps the types in lockstep with the SDK without manually duplicating the interface.

## Testing

- `npx tsc --noEmit` clean
- `npm run build` produces `dist/index.js` with no errors (29.16 KB)
- Live stdio session against real Infisical instance:
  - `create-secret` with `secretComment: "Test comment via MCP create-secret 4-element convention: WHO=..."` → response shows `secretComment` populated, persisted at REST level (verified via separate GET)
  - `update-secret` without `secretComment` → existing comment preserved
  - `update-secret` with no `secretValue` → existing value preserved

This patched binary has been deployed locally in my environment since 2026-05-26 alongside the patch from #22.

## Backward compatibility

Fully additive — all new fields are optional, existing callers unaffected.

The one behavior change is the `update-secret` partial-update fix: previously `secretValue: ""` was always sent (defeating partial updates); now it's only sent when the caller passes it. This is actually the documented intent — see the Infisical REST API docs which describe PATCH semantics. If anyone was relying on the bug as a feature (clearing a value by passing nothing), they can still do so explicitly by passing `secretValue: ""` — the semantics is preserved at the boundary.

## Related

- #21 / #22 (list-secrets value masking) — paired MCP hygiene improvements.
