### PR TITLE
fix(list-projects): omit type=all query param — self-hosted Infisical rejects it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -794,7 +794,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
               id: string;
             }[];
           }[];
-        }>(`${hostUrl}/v1/workspace?type=${data.type}`, {
+        }>(`${hostUrl}/v1/workspace${data.type && data.type !== "all" ? `?type=${data.type}` : ""}`, {
           headers: {
             Authorization: `Bearer ${accessToken}`,
           },


### PR DESCRIPTION
## Problem

`list-projects` always sends `?type=${data.type}` to `GET /v1/workspace`. When `type` is `all` (the schema default), self-hosted Infisical rejects `type=all` as an invalid enum value and returns **HTTP 422**, so the tool fails on every default call against self-hosted instances.

## Fix

Only append `?type=<value>` for the real enum values; omit the query parameter entirely when `type` is unset or `"all"`. No behavior change for Infisical Cloud (which tolerates `type=all`).

```ts
}>(`${hostUrl}/v1/workspace${data.type && data.type !== "all" ? `?type=${data.type}` : ""}`, {
```

One line in `src/index.ts`. `npm run build` passes.

## Context

This supersedes #19 (which inadvertently committed a prebuilt `dist/` bundle, +780 lines — `dist/` is gitignored upstream and built via the `build` script, so it doesn't belong in the diff). This PR is the same source fix, isolated to the one line. Same root cause as #10 and #15.

Verified against a self-hosted Infisical instance: `list-projects` returns `422` before, succeeds after.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
