### PR TITLE
feat: add streamable HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,32 @@ In order to use the MCP server, you must first set the environment variables req
 - `INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET`: The Machine Identity universal auth client secret. Required when `INFISICAL_AUTH_METHOD` is `universal-auth`.
 - `INFISICAL_TOKEN`: An access token for authentication. This can be both a personal access token or a machine identity access token. Required when `INFISICAL_AUTH_METHOD` is `access-token`.
 - `INFISICAL_HOST_URL`: **Optionally** set a custom host URL. This is useful if you're self-hosting Infisical or you're on dedicated infrastructure. Defaults to `https://app.infisical.com`.
+- `MCP_TRANSPORT`: The transport to use. Supported values are `stdio` and `streamable-http`. Defaults to `stdio`.
+- `MCP_HTTP_HOST`: Host interface for `streamable-http` mode. Defaults to `127.0.0.1`.
+- `MCP_HTTP_PORT`: Port for `streamable-http` mode. Defaults to `3333`.
+- `MCP_HTTP_PATH`: HTTP path for `streamable-http` mode. Defaults to `/mcp`.
 
 To run the Infisical MCP server using npx, use the following command:
 
 ```bash
 npx -y @infisical/mcp
 ```
+
+### Streamable HTTP mode
+
+To run the server over Streamable HTTP instead of stdio:
+
+```bash
+MCP_TRANSPORT=streamable-http MCP_HTTP_PORT=3333 node dist/index.js
+```
+
+The server exposes:
+
+- MCP endpoint: `http://127.0.0.1:3333/mcp`
+- Health endpoint: `http://127.0.0.1:3333/health`
+
+This implementation uses the official `StreamableHTTPServerTransport` from
+`@modelcontextprotocol/sdk` and keeps stdio as the default for compatibility.
 
 ### Usage with Claude Desktop
 
@@ -90,6 +110,14 @@ Run the following command in your terminal:
 ```bash
 # Start MCP Inspector and server
 npx @modelcontextprotocol/inspector node dist/index.js
+```
+
+For Streamable HTTP mode, build first and then point your MCP client at the
+configured HTTP endpoint:
+
+```bash
+npm run build
+MCP_TRANSPORT=streamable-http node dist/index.js
 ```
 
 ### Instructions

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ In order to use the MCP server, you must first set the environment variables req
 - `MCP_HTTP_HOST`: Host interface for `streamable-http` mode. Defaults to `127.0.0.1`.
 - `MCP_HTTP_PORT`: Port for `streamable-http` mode. Defaults to `3333`.
 - `MCP_HTTP_PATH`: HTTP path for `streamable-http` mode. Defaults to `/mcp`.
+- `MCP_HTTP_BODY_LIMIT_BYTES`: Maximum accepted HTTP request body size in `streamable-http` mode. Defaults to `4194304` (4 MiB).
+- `MCP_HTTP_SESSION_TTL_MS`: Idle session TTL in `streamable-http` mode. Defaults to `300000` (5 minutes).
 
 To run the Infisical MCP server using npx, use the following command:
 
@@ -39,6 +41,7 @@ The server exposes:
 
 This implementation uses the official `StreamableHTTPServerTransport` from
 `@modelcontextprotocol/sdk` and keeps stdio as the default for compatibility.
+Idle HTTP sessions are automatically reaped after the configured TTL.
 
 ### Usage with Claude Desktop
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@infisical/sdk": "4.0.1",
-        "@modelcontextprotocol/sdk": "^1.9.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.9.0",
         "typescript": "^5.8.3",
         "zod": "^3.24.2"
@@ -448,6 +448,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@infisical/sdk": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@infisical/sdk/-/sdk-4.0.1.tgz",
@@ -532,24 +544,61 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.9.0.tgz",
-      "integrity": "sha512-Jq2EUCQpe0iyO5FGpzVYDNFR6oR53AIrwph9yWl7uSc7IWUMsrmpmSaTGra5hQNunXpM+9oit85p924jWuHzUA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -873,6 +922,39 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
@@ -987,23 +1069,27 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/brace-expansion": {
@@ -1178,15 +1264,16 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -1244,9 +1331,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1470,18 +1557,19 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -1512,10 +1600,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -1523,8 +1614,30 @@
         "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+        "express": ">= 4.11"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.4.3",
@@ -1542,9 +1655,9 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -1555,7 +1668,11 @@
         "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/follow-redirects": {
@@ -1810,32 +1927,49 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -1849,6 +1983,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -1991,6 +2134,15 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -2000,6 +2152,18 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -2085,15 +2249,19 @@
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/minimatch": {
@@ -2234,12 +2402,13 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/picocolors": {
@@ -2359,9 +2528,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -2392,18 +2561,18 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/readdirp": {
@@ -2418,6 +2587,15 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2486,26 +2664,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
@@ -2536,31 +2694,35 @@
       "license": "ISC"
     },
     "node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
         "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -2570,6 +2732,10 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-function-length": {
@@ -2617,14 +2783,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2636,13 +2802,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2715,9 +2881,9 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2996,17 +3162,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -3267,15 +3450,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.24.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "description": "Official Infisical MCP Server",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "tsup src/index.ts --out-dir dist --format cjs --tsconfig tsconfig.json --no-splitting"
+    "build": "tsup src/index.ts --out-dir dist --format cjs --tsconfig tsconfig.json --no-splitting",
+    "test": "npm run build && node --test"
   },
 
   "overrides": {
@@ -35,7 +36,7 @@
 
   "dependencies": {
     "@infisical/sdk": "4.0.1",
-    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.9.0",
     "typescript": "^5.8.3",
     "zod": "^3.24.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,22 @@
 #!/usr/bin/env node
 
 import { InfisicalSDK } from "@infisical/sdk";
+import { randomUUID } from "crypto";
 import fs from "fs";
 import axios from "axios";
+import {
+  createServer as createHttpServer,
+  IncomingMessage,
+  Server as HttpServer,
+  ServerResponse,
+} from "http";
 import path from "path";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import {
   CallToolRequestSchema,
+  isInitializeRequest,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
@@ -16,6 +25,16 @@ enum InfisicalAuthMethod {
   UniversalAuth = "universal-auth",
   TokenAuth = "access-token",
 }
+
+enum McpTransportMode {
+  Stdio = "stdio",
+  StreamableHttp = "streamable-http",
+}
+
+type StreamableSession = {
+  server: Server;
+  transport: StreamableHTTPServerTransport;
+};
 
 const packageJson = JSON.parse(
   fs.readFileSync(path.join(__dirname, "../package.json"), "utf-8"),
@@ -35,6 +54,17 @@ const getEnvironmentVariables = () => {
         .min(1)
         .optional(),
       INFISICAL_HOST_URL: z.string().default("https://app.infisical.com"),
+      MCP_TRANSPORT: z
+        .nativeEnum(McpTransportMode)
+        .default(McpTransportMode.Stdio),
+      MCP_HTTP_HOST: z.string().default("127.0.0.1"),
+      MCP_HTTP_PORT: z.coerce.number().int().positive().default(3333),
+      MCP_HTTP_PATH: z
+        .string()
+        .trim()
+        .min(1)
+        .default("/mcp")
+        .transform((value) => (value.startsWith("/") ? value : `/${value}`)),
     })
     // validate the env vars on startup to avoid runtime errors
     .superRefine((data, ctx) => {
@@ -105,18 +135,6 @@ const handleAuthentication = async () => {
 
   isAuthenticated = true;
 };
-
-const server = new Server(
-  {
-    name: "Infisical",
-    version: packageJson.version,
-  },
-  {
-    capabilities: {
-      tools: {},
-    },
-  },
-);
 
 enum AvailableTools {
   CreateSecret = "create-secret",
@@ -532,7 +550,21 @@ const inviteMembersToProjectSchema = {
     },
   },
 };
-server.setRequestHandler(ListToolsRequestSchema, async () => {
+
+const createMcpServer = () => {
+  const server = new Server(
+    {
+      name: "Infisical",
+      version: packageJson.version,
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
   return {
     tools: [
       createSecretSchema.capability,
@@ -547,9 +579,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       listProjectsSchema.capability,
     ],
   };
-});
+  });
 
-server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
   try {
     await handleAuthentication();
 
@@ -842,9 +874,265 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
     throw err;
   }
-});
+  });
 
-(async () => {
+  return server;
+};
+
+const readRequestBody = async (req: IncomingMessage) => {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  if (chunks.length === 0) {
+    return undefined;
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf-8"));
+};
+
+const sendJson = (
+  res: ServerResponse,
+  statusCode: number,
+  body: Record<string, unknown>,
+) => {
+  const payload = JSON.stringify(body);
+  res.writeHead(statusCode, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(payload),
+  });
+  res.end(payload);
+};
+
+const closeSession = async (
+  sessions: Map<string, StreamableSession>,
+  sessionId: string,
+) => {
+  const session = sessions.get(sessionId);
+  if (!session) {
+    return;
+  }
+
+  sessions.delete(sessionId);
+  await session.transport.close();
+  await session.server.close();
+};
+
+const startStreamableHttpServer = async () => {
+  const sessions = new Map<string, StreamableSession>();
+
+  const server = createHttpServer(async (req, res) => {
+    if (!req.url) {
+      sendJson(res, 400, {
+        jsonrpc: "2.0",
+        error: {
+          code: -32000,
+          message: "Bad Request: Missing request URL.",
+        },
+        id: null,
+      });
+      return;
+    }
+
+    const requestUrl = new URL(req.url, "http://localhost");
+
+    if (requestUrl.pathname === "/health" && req.method === "GET") {
+      sendJson(res, 200, {
+        status: "ok",
+        transport: McpTransportMode.StreamableHttp,
+        path: env.MCP_HTTP_PATH,
+        version: packageJson.version,
+      });
+      return;
+    }
+
+    if (requestUrl.pathname !== env.MCP_HTTP_PATH) {
+      sendJson(res, 404, {
+        jsonrpc: "2.0",
+        error: {
+          code: -32000,
+          message: "Not Found.",
+        },
+        id: null,
+      });
+      return;
+    }
+
+    try {
+      switch (req.method) {
+        case "POST": {
+          const requestBody = await readRequestBody(req);
+          const sessionId = req.headers["mcp-session-id"];
+          const normalizedSessionId =
+            typeof sessionId === "string" ? sessionId : undefined;
+
+          if (normalizedSessionId) {
+            const existingSession = sessions.get(normalizedSessionId);
+            if (!existingSession) {
+              sendJson(res, 404, {
+                jsonrpc: "2.0",
+                error: {
+                  code: -32000,
+                  message: "Session not found.",
+                },
+                id: null,
+              });
+              return;
+            }
+
+            await existingSession.transport.handleRequest(req, res, requestBody);
+            return;
+          }
+
+          if (!isInitializeRequest(requestBody)) {
+            sendJson(res, 400, {
+              jsonrpc: "2.0",
+              error: {
+                code: -32000,
+                message: "Bad Request: No valid session ID provided.",
+              },
+              id: null,
+            });
+            return;
+          }
+
+          const sessionServer = createMcpServer();
+          const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            enableJsonResponse: true,
+            onsessioninitialized: (newSessionId) => {
+              sessions.set(newSessionId, {
+                server: sessionServer,
+                transport,
+              });
+            },
+          });
+
+          transport.onclose = () => {
+            const transportSessionId = transport.sessionId;
+            if (transportSessionId) {
+              sessions.delete(transportSessionId);
+            }
+          };
+
+          await sessionServer.connect(transport);
+          await transport.handleRequest(req, res, requestBody);
+          return;
+        }
+        case "GET": {
+          res.writeHead(405, { allow: "POST, DELETE" });
+          res.end("Method Not Allowed");
+          return;
+        }
+        case "DELETE": {
+          const sessionId = req.headers["mcp-session-id"];
+          const normalizedSessionId =
+            typeof sessionId === "string" ? sessionId : undefined;
+
+          if (!normalizedSessionId || !sessions.has(normalizedSessionId)) {
+            sendJson(res, 404, {
+              jsonrpc: "2.0",
+              error: {
+                code: -32000,
+                message: "Session not found.",
+              },
+              id: null,
+            });
+            return;
+          }
+
+          const session = sessions.get(normalizedSessionId)!;
+          await session.transport.handleRequest(req, res);
+          await closeSession(sessions, normalizedSessionId);
+          return;
+        }
+        default: {
+          res.writeHead(405, { allow: "GET, POST, DELETE" });
+          res.end("Method Not Allowed");
+          return;
+        }
+      }
+    } catch (error) {
+      console.error("Failed to handle streamable HTTP request", error);
+      if (!res.headersSent) {
+        sendJson(res, 500, {
+          jsonrpc: "2.0",
+          error: {
+            code: -32603,
+            message: "Internal server error.",
+          },
+          id: null,
+        });
+      }
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(env.MCP_HTTP_PORT, env.MCP_HTTP_HOST, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const closeAllSessions = async () => {
+    const activeSessionIds = [...sessions.keys()];
+    for (const sessionId of activeSessionIds) {
+      await closeSession(sessions, sessionId);
+    }
+  };
+
+  const shutdown = async () => {
+    await closeAllSessions();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  };
+
+  process.on("SIGINT", () => {
+    void shutdown().finally(() => process.exit(0));
+  });
+
+  process.on("SIGTERM", () => {
+    void shutdown().finally(() => process.exit(0));
+  });
+
+  console.error(
+    `Infisical MCP Server running on streamable HTTP at http://${env.MCP_HTTP_HOST}:${env.MCP_HTTP_PORT}${env.MCP_HTTP_PATH} ✅`,
+  );
+};
+
+const startStdioServer = async () => {
+  const server = createMcpServer();
   await server.connect(new StdioServerTransport());
   console.error("Infisical MCP Server running on stdio ✅");
-})();
+};
+
+const main = async () => {
+  switch (env.MCP_TRANSPORT) {
+    case McpTransportMode.Stdio:
+      await startStdioServer();
+      break;
+    case McpTransportMode.StreamableHttp:
+      await startStreamableHttpServer();
+      break;
+    default:
+      throw new Error(`Unsupported MCP transport: ${env.MCP_TRANSPORT}`);
+  }
+};
+
+if (require.main === module) {
+  void main().catch((error) => {
+    console.error("Failed to start Infisical MCP Server", error);
+    process.exit(1);
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,9 +32,20 @@ enum McpTransportMode {
 }
 
 type StreamableSession = {
+  lastActivityAt: number;
   server: Server;
   transport: StreamableHTTPServerTransport;
 };
+
+class HttpTransportError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly jsonRpcCode: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
 
 const packageJson = JSON.parse(
   fs.readFileSync(path.join(__dirname, "../package.json"), "utf-8"),
@@ -65,6 +76,12 @@ const getEnvironmentVariables = () => {
         .min(1)
         .default("/mcp")
         .transform((value) => (value.startsWith("/") ? value : `/${value}`)),
+      MCP_HTTP_BODY_LIMIT_BYTES: z.coerce
+        .number()
+        .int()
+        .positive()
+        .default(4 * 1024 * 1024),
+      MCP_HTTP_SESSION_TTL_MS: z.coerce.number().int().positive().default(300000),
     })
     // validate the env vars on startup to avoid runtime errors
     .superRefine((data, ctx) => {
@@ -881,16 +898,39 @@ const createMcpServer = () => {
 
 const readRequestBody = async (req: IncomingMessage) => {
   const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  let bodyLimitExceeded = false;
 
   for await (const chunk of req) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    const bufferChunk = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += bufferChunk.byteLength;
+
+    if (totalBytes > env.MCP_HTTP_BODY_LIMIT_BYTES) {
+      bodyLimitExceeded = true;
+      req.resume();
+      break;
+    }
+
+    chunks.push(bufferChunk);
+  }
+
+  if (bodyLimitExceeded) {
+    throw new HttpTransportError(
+      413,
+      -32000,
+      `Request body exceeds ${env.MCP_HTTP_BODY_LIMIT_BYTES} bytes.`,
+    );
   }
 
   if (chunks.length === 0) {
     return undefined;
   }
 
-  return JSON.parse(Buffer.concat(chunks).toString("utf-8"));
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf-8"));
+  } catch {
+    throw new HttpTransportError(400, -32700, "Malformed JSON request body.");
+  }
 };
 
 const sendJson = (
@@ -904,6 +944,11 @@ const sendJson = (
     "content-length": Buffer.byteLength(payload),
   });
   res.end(payload);
+};
+
+const sendMethodNotAllowed = (res: ServerResponse) => {
+  res.writeHead(405, { allow: "POST, DELETE" });
+  res.end("Method Not Allowed");
 };
 
 const closeSession = async (
@@ -920,8 +965,57 @@ const closeSession = async (
   await session.server.close();
 };
 
+const touchSession = (session: StreamableSession) => {
+  session.lastActivityAt = Date.now();
+};
+
+const isSessionIdle = (session: StreamableSession) =>
+  Date.now() - session.lastActivityAt > env.MCP_HTTP_SESSION_TTL_MS;
+
+const getActiveSession = async (
+  sessions: Map<string, StreamableSession>,
+  sessionId: string,
+) => {
+  const session = sessions.get(sessionId);
+  if (!session) {
+    return undefined;
+  }
+
+  if (isSessionIdle(session)) {
+    await closeSession(sessions, sessionId);
+    return undefined;
+  }
+
+  touchSession(session);
+  return session;
+};
+
 const startStreamableHttpServer = async () => {
   const sessions = new Map<string, StreamableSession>();
+  const sweepIntervalMs = Math.max(
+    1000,
+    Math.min(env.MCP_HTTP_SESSION_TTL_MS, 60000),
+  );
+
+  const sweepIdleSessions = async () => {
+    const activeSessionIds = [...sessions.keys()];
+
+    for (const sessionId of activeSessionIds) {
+      const session = sessions.get(sessionId);
+      if (!session || !isSessionIdle(session)) {
+        continue;
+      }
+
+      await closeSession(sessions, sessionId);
+    }
+  };
+
+  const sweepTimer = setInterval(() => {
+    void sweepIdleSessions().catch((error) => {
+      console.error("Failed to sweep idle MCP sessions", error);
+    });
+  }, sweepIntervalMs);
+  sweepTimer.unref();
 
   const server = createHttpServer(async (req, res) => {
     if (!req.url) {
@@ -969,7 +1063,10 @@ const startStreamableHttpServer = async () => {
             typeof sessionId === "string" ? sessionId : undefined;
 
           if (normalizedSessionId) {
-            const existingSession = sessions.get(normalizedSessionId);
+            const existingSession = await getActiveSession(
+              sessions,
+              normalizedSessionId,
+            );
             if (!existingSession) {
               sendJson(res, 404, {
                 jsonrpc: "2.0",
@@ -1004,6 +1101,7 @@ const startStreamableHttpServer = async () => {
             enableJsonResponse: true,
             onsessioninitialized: (newSessionId) => {
               sessions.set(newSessionId, {
+                lastActivityAt: Date.now(),
                 server: sessionServer,
                 transport,
               });
@@ -1022,8 +1120,7 @@ const startStreamableHttpServer = async () => {
           return;
         }
         case "GET": {
-          res.writeHead(405, { allow: "POST, DELETE" });
-          res.end("Method Not Allowed");
+          sendMethodNotAllowed(res);
           return;
         }
         case "DELETE": {
@@ -1031,7 +1128,7 @@ const startStreamableHttpServer = async () => {
           const normalizedSessionId =
             typeof sessionId === "string" ? sessionId : undefined;
 
-          if (!normalizedSessionId || !sessions.has(normalizedSessionId)) {
+          if (!normalizedSessionId) {
             sendJson(res, 404, {
               jsonrpc: "2.0",
               error: {
@@ -1043,18 +1140,43 @@ const startStreamableHttpServer = async () => {
             return;
           }
 
-          const session = sessions.get(normalizedSessionId)!;
+          const session = await getActiveSession(sessions, normalizedSessionId);
+          if (!session) {
+            sendJson(res, 404, {
+              jsonrpc: "2.0",
+              error: {
+                code: -32000,
+                message: "Session not found.",
+              },
+              id: null,
+            });
+            return;
+          }
+
           await session.transport.handleRequest(req, res);
           await closeSession(sessions, normalizedSessionId);
           return;
         }
         default: {
-          res.writeHead(405, { allow: "GET, POST, DELETE" });
-          res.end("Method Not Allowed");
+          sendMethodNotAllowed(res);
           return;
         }
       }
     } catch (error) {
+      if (error instanceof HttpTransportError) {
+        if (!res.headersSent) {
+          sendJson(res, error.statusCode, {
+            jsonrpc: "2.0",
+            error: {
+              code: error.jsonRpcCode,
+              message: error.message,
+            },
+            id: null,
+          });
+        }
+        return;
+      }
+
       console.error("Failed to handle streamable HTTP request", error);
       if (!res.headersSent) {
         sendJson(res, 500, {
@@ -1085,6 +1207,7 @@ const startStreamableHttpServer = async () => {
   };
 
   const shutdown = async () => {
+    clearInterval(sweepTimer);
     await closeAllSessions();
     await new Promise<void>((resolve, reject) => {
       server.close((error) => {

--- a/test/streamable-http.test.js
+++ b/test/streamable-http.test.js
@@ -48,7 +48,7 @@ const waitForHealth = async (url, childProcess) => {
   throw lastError;
 };
 
-test("streamable HTTP transport initializes and exposes tools", async (t) => {
+const startHttpServer = async (t, envOverrides = {}) => {
   const port = await getFreePort();
   const childProcess = spawn(process.execPath, ["dist/index.js"], {
     cwd: repoRoot,
@@ -61,6 +61,7 @@ test("streamable HTTP transport initializes and exposes tools", async (t) => {
       MCP_HTTP_HOST: "127.0.0.1",
       MCP_HTTP_PORT: String(port),
       MCP_HTTP_PATH: "/mcp",
+      ...envOverrides,
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -82,7 +83,16 @@ test("streamable HTTP transport initializes and exposes tools", async (t) => {
 
   await waitForHealth(`http://127.0.0.1:${port}/health`, childProcess);
 
-  const initializeResponse = await fetch(`http://127.0.0.1:${port}/mcp`, {
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    stderrChunks,
+  };
+};
+
+test("streamable HTTP transport initializes and exposes tools", async (t) => {
+  const { baseUrl, stderrChunks } = await startHttpServer(t);
+
+  const initializeResponse = await fetch(`${baseUrl}/mcp`, {
     method: "POST",
     headers: {
       accept: "application/json, text/event-stream",
@@ -115,7 +125,7 @@ test("streamable HTTP transport initializes and exposes tools", async (t) => {
   const initializePayload = await initializeResponse.json();
   assert.equal(initializePayload.result.serverInfo.name, "Infisical");
 
-  const listToolsResponse = await fetch(`http://127.0.0.1:${port}/mcp`, {
+  const listToolsResponse = await fetch(`${baseUrl}/mcp`, {
     method: "POST",
     headers: {
       accept: "application/json, text/event-stream",
@@ -140,4 +150,114 @@ test("streamable HTTP transport initializes and exposes tools", async (t) => {
   const toolNames = listToolsPayload.result.tools.map((tool) => tool.name);
   assert.ok(toolNames.includes("create-secret"));
   assert.ok(toolNames.includes("list-projects"));
+});
+
+test("streamable HTTP transport returns 400 for malformed JSON", async (t) => {
+  const { baseUrl } = await startHttpServer(t);
+
+  const response = await fetch(`${baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    },
+    body: "{invalid-json",
+  });
+
+  assert.equal(response.status, 400);
+  const payload = await response.json();
+  assert.equal(payload.error.code, -32700);
+});
+
+test("streamable HTTP transport returns 413 for oversized bodies", async (t) => {
+  const { baseUrl } = await startHttpServer(t, {
+    MCP_HTTP_BODY_LIMIT_BYTES: "128",
+  });
+
+  const response = await fetch(`${baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: {
+          name: "test-client",
+          version: "1.0.0",
+        },
+        padding: "x".repeat(512),
+      },
+    }),
+  });
+
+  assert.equal(response.status, 413);
+  const payload = await response.json();
+  assert.equal(payload.error.code, -32000);
+});
+
+test("streamable HTTP transport reaps idle sessions", async (t) => {
+  const { baseUrl } = await startHttpServer(t, {
+    MCP_HTTP_SESSION_TTL_MS: "50",
+  });
+
+  const initializeResponse = await fetch(`${baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: {
+          name: "test-client",
+          version: "1.0.0",
+        },
+      },
+    }),
+  });
+
+  assert.equal(initializeResponse.status, 200);
+  const sessionId = initializeResponse.headers.get("mcp-session-id");
+  assert.ok(sessionId);
+
+  await delay(120);
+
+  const listToolsResponse = await fetch(`${baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+      "mcp-session-id": sessionId,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+      params: {},
+    }),
+  });
+
+  assert.equal(listToolsResponse.status, 404);
+});
+
+test("streamable HTTP transport advertises only supported methods", async (t) => {
+  const { baseUrl } = await startHttpServer(t);
+
+  const response = await fetch(`${baseUrl}/mcp`, {
+    method: "PATCH",
+  });
+
+  assert.equal(response.status, 405);
+  assert.equal(response.headers.get("allow"), "POST, DELETE");
 });

--- a/test/streamable-http.test.js
+++ b/test/streamable-http.test.js
@@ -1,0 +1,143 @@
+const assert = require("node:assert/strict");
+const { spawn } = require("node:child_process");
+const net = require("node:net");
+const path = require("node:path");
+const test = require("node:test");
+const { setTimeout: delay } = require("node:timers/promises");
+
+const repoRoot = path.resolve(__dirname, "..");
+
+const getFreePort = () =>
+  new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close((closeError) => {
+        if (closeError) {
+          reject(closeError);
+          return;
+        }
+
+        resolve(address.port);
+      });
+    });
+    server.on("error", reject);
+  });
+
+const waitForHealth = async (url, childProcess) => {
+  let lastError;
+
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (childProcess.exitCode !== null) {
+      throw new Error(`Server exited early with code ${childProcess.exitCode}`);
+    }
+
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+      lastError = new Error(`Healthcheck returned ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    await delay(100);
+  }
+
+  throw lastError;
+};
+
+test("streamable HTTP transport initializes and exposes tools", async (t) => {
+  const port = await getFreePort();
+  const childProcess = spawn(process.execPath, ["dist/index.js"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      INFISICAL_AUTH_METHOD: "access-token",
+      INFISICAL_TOKEN: "test-token",
+      INFISICAL_HOST_URL: "https://app.infisical.com",
+      MCP_TRANSPORT: "streamable-http",
+      MCP_HTTP_HOST: "127.0.0.1",
+      MCP_HTTP_PORT: String(port),
+      MCP_HTTP_PATH: "/mcp",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const stderrChunks = [];
+  childProcess.stderr.on("data", (chunk) => {
+    stderrChunks.push(chunk.toString("utf-8"));
+  });
+
+  t.after(async () => {
+    if (childProcess.exitCode === null) {
+      childProcess.kill("SIGTERM");
+      await Promise.race([
+        new Promise((resolve) => childProcess.once("exit", resolve)),
+        delay(3_000),
+      ]);
+    }
+  });
+
+  await waitForHealth(`http://127.0.0.1:${port}/health`, childProcess);
+
+  const initializeResponse = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: "POST",
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: {
+          name: "test-client",
+          version: "1.0.0",
+        },
+      },
+    }),
+  });
+
+  assert.equal(
+    initializeResponse.status,
+    200,
+    stderrChunks.join(""),
+  );
+
+  const sessionId = initializeResponse.headers.get("mcp-session-id");
+  assert.ok(sessionId, "Expected MCP session ID header on initialization");
+
+  const initializePayload = await initializeResponse.json();
+  assert.equal(initializePayload.result.serverInfo.name, "Infisical");
+
+  const listToolsResponse = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: "POST",
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+      "mcp-session-id": sessionId,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+      params: {},
+    }),
+  });
+
+  assert.equal(
+    listToolsResponse.status,
+    200,
+    stderrChunks.join(""),
+  );
+
+  const listToolsPayload = await listToolsResponse.json();
+  const toolNames = listToolsPayload.result.tools.map((tool) => tool.name);
+  assert.ok(toolNames.includes("create-secret"));
+  assert.ok(toolNames.includes("list-projects"));
+});


### PR DESCRIPTION
## Summary
- add dual transport support so the server can run over stdio or official MCP streamable HTTP
- keep stdio as the default transport for backwards compatibility
- document the new transport env vars and HTTP endpoint usage in the README
- add a smoke test that boots the built server in `streamable-http` mode, initializes an MCP session, and lists tools

## Why
The repository currently starts only with `StdioServerTransport`, which makes it harder to use in MCP runtimes that expect streamable HTTP. This change keeps the existing stdio behavior intact while adding a transport mode based on the official `StreamableHTTPServerTransport` from `@modelcontextprotocol/sdk`.

## Design
- `MCP_TRANSPORT=stdio` remains the default
- `MCP_TRANSPORT=streamable-http` starts an HTTP server with:
  - `MCP_HTTP_HOST` (default `127.0.0.1`)
  - `MCP_HTTP_PORT` (default `3333`)
  - `MCP_HTTP_PATH` (default `/mcp`)
- implementation uses the SDK's built-in `StreamableHTTPServerTransport`
- no FlowMCP wrapper or extra HTTP framework was introduced

## Verification
- `npm test`

## Risks
- upgrades `@modelcontextprotocol/sdk` from `^1.9.0` to `^1.29.0`
- repo currently has no PR-triggered CI workflow; the existing GitHub Actions workflow runs only on tag pushes

## Rollback
- revert this PR to remove the new transport mode and restore stdio-only startup

## New env / secrets
- New non-secret env vars: `MCP_TRANSPORT`, `MCP_HTTP_HOST`, `MCP_HTTP_PORT`, `MCP_HTTP_PATH`
- No new secrets

## Migrations
- None

## Related
- This is a narrower alternative to the larger closed PR #12, using the official SDK transport instead of a custom FlowMCP server.