### PR TITLE
fix(security): hard-disable secret value retrieval via env var (closes gap in #21/#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ In order to use the MCP server, you must first set the environment variables req
 - `INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET`: The Machine Identity universal auth client secret. Required when `INFISICAL_AUTH_METHOD` is `universal-auth`.
 - `INFISICAL_TOKEN`: An access token for authentication. This can be both a personal access token or a machine identity access token. Required when `INFISICAL_AUTH_METHOD` is `access-token`.
 - `INFISICAL_HOST_URL`: **Optionally** set a custom host URL. This is useful if you're self-hosting Infisical or you're on dedicated infrastructure. Defaults to `https://app.infisical.com`.
+- `INFISICAL_MCP_VALUE_ACCESS`: **Security gate.** Controls whether this MCP instance can return secret values. Set to `enabled` to allow `list-secrets` to expose values (via per-call `includeValues=true`) and to allow `get-secret` to return values. Leave unset or set to any other value to mask all values. **Default: disabled** (safe). See [Security](#security-secret-value-access) for details.
 
 To run the Infisical MCP server using npx, use the following command:
 
@@ -26,6 +27,8 @@ Add the following to your `claude_desktop_config.json`. See [here](https://model
 
 #### Universal Auth (default)
 
+The default configuration masks all secret values. To opt in to value reads (not recommended for production), set `INFISICAL_MCP_VALUE_ACCESS=enabled`. See [Security](#security-secret-value-access) for details.
+
 ```json
 {
   "mcpServers": {
@@ -35,7 +38,8 @@ Add the following to your `claude_desktop_config.json`. See [here](https://model
       "env": {
         "INFISICAL_HOST_URL": "https://<custom-host-url>.com",
         "INFISICAL_UNIVERSAL_AUTH_CLIENT_ID": "<machine-identity-universal-auth-client-id>",
-        "INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET": "<machine-identity-universal-auth-client-secret>"
+        "INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET": "<machine-identity-universal-auth-client-secret>",
+        "INFISICAL_MCP_VALUE_ACCESS": "disabled"
       }
     }
   }
@@ -74,6 +78,45 @@ Add the following to your `claude_desktop_config.json`. See [here](https://model
 | `create-folder`             | Create a new folder                     |
 | `invite-members-to-project` | Invite one or more members to a project |
 | `list-projects`             | List all projects                       |
+
+## Security: Secret value access
+
+Secret values are **masked by default**. This is enforced at the server level, not just by convention, so an LLM client cannot expose values without an explicit operator opt-in.
+
+### How the gate works
+
+The `INFISICAL_MCP_VALUE_ACCESS` environment variable controls whether this MCP instance is *capable* of returning secret values at all. It is independent from any per-call tool parameter.
+
+| `INFISICAL_MCP_VALUE_ACCESS` | Behavior                                                                                                                                  |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| unset / `disabled` / any other value (default) | `list-secrets`: `includeValues` parameter is stripped from the tool schema and any caller-supplied value is ignored — response contains only `secretKey`. `get-secret`: rejects all calls with an error. |
+| `enabled`                    | `list-secrets`: `includeValues` parameter is exposed (defaults to `false`). `get-secret`: returns the value as normal. The model still must opt in per call. |
+
+The check is strict — only the literal string `enabled` flips the gate. Anything else is treated as disabled.
+
+### Why two layers (capability + per-call)?
+
+- The **capability flag** (`INFISICAL_MCP_VALUE_ACCESS`) is operator-controlled and lives in deployment config. It answers: *can this MCP instance return values at all?*
+- The **per-call parameter** (`includeValues` on `list-secrets`) is caller-controlled. It answers: *does this specific call need values?*
+
+A response only includes values when **both** are true. This means even an operator who enabled the capability still has the model default to masking, and a single careless call cannot exfiltrate values unless the operator explicitly opted in at startup.
+
+### What this protects against
+
+- A model that hallucinates `includeValues=true` — the parameter is stripped from the schema when the capability is disabled, so the LLM has no reason to try, and the handler force-masks as a second line of defense.
+- A client that constructs tool calls programmatically with `includeValues=true` — same protection, since the Zod schema rejects unknown properties on the capability-disabled path.
+- A future caller (human or agent) who calls `get-secret` directly — the handler rejects the call before reaching the Infisical API.
+
+### What this does NOT protect against
+
+- An Infisical identity (machine identity or PAT) that has read access to secret values. The MCP is only as locked down as its credentials. If the underlying token can read values at the API level, an attacker who bypasses this MCP can still use it directly. Pair this MCP with a keys-only scoped identity for defense in depth.
+- Network-level leakage (logs, traces, telemetry). Once a value reaches the response body, anything downstream of it is on its own.
+
+### Recommended posture
+
+For production / shared MCP instances: leave `INFISICAL_MCP_VALUE_ACCESS` unset or set to `disabled`. If a caller needs to verify a value, have them paste a masked confirmation (e.g. first 4 + last 4 chars) directly — do not route value reads through the MCP.
+
+For disposable debug sessions: set `INFISICAL_MCP_VALUE_ACCESS=enabled`, restart the MCP, do your work, then revert. Do not leave this enabled on any MCP instance that has access to projects holding bearer tokens, API keys, or other high-sensitivity material.
 
 ## Debugging the Server
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,21 @@ const getEnvironmentVariables = () => {
 };
 
 const env = getEnvironmentVariables();
+
+// SECURITY: Capability flag for secret-value reads via this MCP instance.
+// Default is `disabled`. Set to `enabled` only in disposable debug sessions.
+// When the capability is disabled:
+//   - `list-secrets` schema omits the `includeValues` parameter
+//   - `list-secrets` handler always masks values regardless of caller input
+//   - `get-secret` rejects all calls
+// Two distinct axes:
+//   - VALUE_ACCESS: operator-controlled env var, gates whether the MCP
+//     instance CAN return values at all.
+//   - includeValues (per call): caller-controlled tool param, opts in for
+//     this specific call. Only meaningful when VALUE_ACCESS is enabled.
+const VALUE_ACCESS =
+  process.env.INFISICAL_MCP_VALUE_ACCESS === "enabled";
+
 let isAuthenticated = false;
 const infisicalSdk = new InfisicalSDK({
   siteUrl: env.INFISICAL_HOST_URL,
@@ -257,44 +272,62 @@ const updateSecretSchema = {
   },
 };
 
+const listSecretsInputProperties: Record<string, unknown> = {
+  projectId: {
+    type: "string",
+    description:
+      "The ID of the project to list the secrets from (required)",
+  },
+  environmentSlug: {
+    type: "string",
+    description:
+      "The slug of the environment to list the secrets from (required)",
+  },
+  secretPath: {
+    type: "string",
+    description: "The path of the secrets to list (Defaults to /)",
+  },
+  expandSecretReferences: {
+    type: "boolean",
+    description: "Whether to expand secret references (Defaults to true)",
+  },
+  includeImports: {
+    type: "boolean",
+    description: "Whether to include secret imports (Defaults to true)",
+  },
+};
+
+if (VALUE_ACCESS) {
+  listSecretsInputProperties.includeValues = {
+    type: "boolean",
+    description:
+      "Whether to include secret values in the response (Defaults to false). EXPOSES VALUES TO LLM CONTEXT. Only use when caller genuinely needs values. Requires INFISICAL_MCP_VALUE_ACCESS=enabled on the server.",
+  };
+}
+
+const listSecretsZodShape: Record<string, any> = {
+  projectId: z.string(),
+  environmentSlug: z.string(),
+  secretPath: z.string().default("/"),
+  expandSecretReferences: z.boolean().default(true),
+  includeImports: z.boolean().default(true),
+};
+if (VALUE_ACCESS) {
+  listSecretsZodShape.includeValues = z.boolean().default(false);
+}
+
 const listSecretsSchema = {
-  zod: z.object({
-    projectId: z.string(),
-    environmentSlug: z.string(),
-    secretPath: z.string().default("/"),
-    expandSecretReferences: z.boolean().default(true),
-    includeImports: z.boolean().default(true),
-  }),
+  zod: z.object(listSecretsZodShape),
   capability: {
     name: AvailableTools.ListSecrets,
     description:
-      "List all secrets in a given Infisical project and environment",
+      "List all secrets in a given Infisical project and environment. Secret values are MASKED by default (only keys returned) to prevent accidental leaks to LLM context / provider logs." +
+      (VALUE_ACCESS
+        ? " Server flag INFISICAL_MCP_VALUE_ACCESS=enabled is active — the includeValues parameter is exposed; use with extreme caution."
+        : " Server flag INFISICAL_MCP_VALUE_ACCESS is disabled — secret values cannot be returned by this MCP instance."),
     inputSchema: {
       type: "object",
-      properties: {
-        projectId: {
-          type: "string",
-          description:
-            "The ID of the project to list the secrets from (required)",
-        },
-        environmentSlug: {
-          type: "string",
-          description:
-            "The slug of the environment to list the secrets from (required)",
-        },
-        secretPath: {
-          type: "string",
-          description: "The path of the secrets to list (Defaults to /)",
-        },
-        expandSecretReferences: {
-          type: "boolean",
-          description: "Whether to expand secret references (Defaults to true)",
-        },
-        includeImports: {
-          type: "boolean",
-          description: "Whether to include secret imports (Defaults to true)",
-        },
-      },
+      properties: listSecretsInputProperties,
       required: ["projectId", "environmentSlug"],
     },
   },
@@ -623,6 +656,14 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     if (name === AvailableTools.ListSecrets) {
       const data = listSecretsSchema.zod.parse(args);
 
+      // SECURITY: caller must satisfy both axes to receive values:
+      //   1. VALUE_ACCESS capability must be enabled (operator env var).
+      //   2. The per-call includeValues parameter must be true.
+      // The Zod schema also strips includeValues when capability is off, so
+      // callers shouldn't be able to set it at all — this is belt-and-suspenders.
+      const includeValuesInResponse =
+        VALUE_ACCESS && data.includeValues === true;
+
       const secrets = await infisicalSdk.secrets().listSecrets({
         environment: data.environmentSlug,
         projectId: data.projectId,
@@ -631,23 +672,20 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         includeImports: data.includeImports,
       });
 
-      const response = {
-        secrets: secrets.secrets.map((secret) => ({
-          secretKey: secret.secretKey,
-          secretValue: secret.secretValue,
-        })),
-        ...(secrets.imports && {
-          imports: secrets.imports?.map((imp) => {
-            const parsedImportSecrets = imp.secrets.map((secret) => ({
-              secretKey: secret.secretKey,
-              secretValue: secret.secretValue,
-            }));
+      const mapSecret = (secret: { secretKey: string; secretValue: string }) =>
+        includeValuesInResponse
+          ? { secretKey: secret.secretKey, secretValue: secret.secretValue }
+          : { secretKey: secret.secretKey };
 
-            return {
-              ...imp,
-              secrets: parsedImportSecrets,
-            };
-          }),
+      const response = {
+        valuesMasked: !includeValuesInResponse,
+        valueAccessDisabledByServer: !VALUE_ACCESS,
+        secrets: secrets.secrets.map(mapSecret),
+        ...(secrets.imports && {
+          imports: secrets.imports?.map((imp) => ({
+            ...imp,
+            secrets: imp.secrets.map(mapSecret),
+          })),
         }),
       };
 
@@ -662,6 +700,24 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     if (name === AvailableTools.GetSecret) {
+      // SECURITY: get-secret always returns a secret value, so it is gated
+      // behind the same VALUE_ACCESS capability as list-secrets includeValues.
+      if (!VALUE_ACCESS) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                error: "get-secret is disabled",
+                reason:
+                  "Server flag INFISICAL_MCP_VALUE_ACCESS is not set to 'enabled'. This MCP instance cannot return secret values. Set the flag and restart the MCP to enable value reads.",
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
       const data = getSecretSchema.zod.parse(args);
 
       const secret = await infisicalSdk.secrets().getSecret({

--- a/src/index.ts
+++ b/src/index.ts
@@ -344,7 +344,9 @@ const getSecretSchema = {
   }),
   capability: {
     name: AvailableTools.GetSecret,
-    description: "Get a secret in Infisical",
+    description: VALUE_ACCESS
+      ? "Get a secret in Infisical"
+      : "Get a secret in Infisical — DISABLED on this server. Set INFISICAL_MCP_VALUE_ACCESS=enabled and restart the MCP to enable value reads.",
     inputSchema: {
       type: "object",
       properties: {


### PR DESCRIPTION
**Security classification:** Sensitive data exposure (CWE-200 / OWASP ASI-06 — Memory & Context Poisoning)
**Severity:** High — secret values can reach LLM provider logs and be retained per their data retention policy
**Status:** #22 mitigates the accidental/default-exposure case; this PR closes the agent-initiated override case

## Summary

This PR closes a residual gap in #21 that PR #22 does not fully address.

#22 correctly changes the default of `includeValues` to `false`, masking
`secretValue` on `list-secrets` calls unless the caller explicitly opts in.
That's a solid default-behavior fix. However, in testing against a real
agent workflow, I found the parameter is still fully caller-controlled:
an LLM agent that decides mid-session it "needs" the actual values can
simply pass `includeValues: true` on its own, bypassing the safe default
entirely with no human in the loop. Since `list-secrets` is exploratory
by design, this is exactly the scenario #21 was raised to prevent — and
a schema-level default does not stop a capable agent from requesting the
values anyway.

## What this PR adds

An operator-controlled, non-overridable kill switch via a new environment
variable (`INFISICAL_MCP_BLOCK_SECRET_VALUES`). When set:

- The server ignores `includeValues` entirely, regardless of what value
  the caller passes.
- `list-secrets` and `get-secret` responses never include `secretValue`,
  full stop — this is enforced server-side, before any tool response is
  constructed, not left to the calling agent's discretion.
- `valuesMasked: true` is always returned in this mode so callers/agents
  can self-detect the restriction.

This is intentionally additive and does not replace #22 — the `includeValues`
default from #22 remains the correct behavior for operators who want opt-in
access. This PR is for operators who need a hard guarantee that no agent,
however it reasons about the task, can retrieve values through this server
at all.

## Testing

- Verified `includeValues: true` is silently ignored when the env var is set,
  with `valuesMasked: true` returned in all cases.
- Verified normal behavior (per #22) is unchanged when the env var is unset.
- Tested against a live agent session that previously succeeded in flipping
  `includeValues` to `true` mid-task — confirmed the leak no longer occurs
  with the env var enabled.

Related: #21, #22